### PR TITLE
Add AGENTS.md for Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a PHP SDK library (`tilta-io/tilta-php-sdk`) — no running application server; it is a Composer package tested via PHPUnit, PHPStan, and coding-standard tools.
+
+### Quick reference (all commands from repo root)
+
+| Task | Command |
+|---|---|
+| Install dependencies | `composer install` |
+| Lint (rector + ecs) | `composer lint` |
+| Static analysis (PHPStan level 9) | `composer phpstan` |
+| Run all tests | `composer phpunit` |
+| Run offline-only tests (no API creds) | `./vendor/bin/phpunit -c phpunit.xml.dist tests/Functional/Util tests/Functional/Model tests/Acceptance` |
+
+### Test suites and API credentials
+
+- **Offline tests** (`tests/Functional/Model`, `tests/Functional/Util`, `tests/Acceptance`) run entirely with mocked data and require no environment variables.
+- **Online/integration tests** (`tests/Functional/Service`, `tests/Functional/FullTest`) make real HTTP calls to the Tilta staging API and require the following env vars: `TILTA_API_TOKEN`, `TILTA_MERCHANT_ID`, `TILTA_TEST_BUYER`. Without these, those tests will fail with `UserNotAuthorizedException`.
+- `TILTA_SDK_API_DOMAIN` defaults to `api.tilta-stage.io` in `phpunit.xml.dist`.
+
+### System requirements
+
+- PHP 8.1+ with extensions: `curl`, `json`, `mbstring`, `xml`, `zip`.
+- Composer 2.x.
+- No database or Docker required.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents working in this PHP SDK repository.

### What's included

- Quick reference table for all dev commands (`composer install`, `composer lint`, `composer phpstan`, `composer phpunit`)
- Documentation of test suites: which require API credentials vs which run offline
- Required environment variables for online/integration tests (`TILTA_API_TOKEN`, `TILTA_MERCHANT_ID`, `TILTA_TEST_BUYER`)
- System requirements (PHP 8.1+, extensions, Composer)

### Environment verification

All development tools verified working:

[dev_environment_test_output.log](https://cursor.com/agents/bc-d1bfc631-cedf-4b3e-aabe-fc4ae8e79584/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_environment_test_output.log)

- **Lint (rector + ecs):** Passes with no issues
- **PHPStan (level 9):** No errors
- **Offline tests (Model/Util/Acceptance):** 69 tests, 205 assertions — all pass
- **Online tests:** 16 tests require API credentials (expected `UserNotAuthorizedException` without them)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1bfc631-cedf-4b3e-aabe-fc4ae8e79584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1bfc631-cedf-4b3e-aabe-fc4ae8e79584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

